### PR TITLE
README.md: Add a link to the talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 This is a core library that models the borrow check. It implements the analysis
-[described in this blogpost][post]. Details are [in the Polonius book][book].
+described in this [blogpost][post] and in this [talk]. Details are [in the Polonius book][book].
 
 [post]: http://smallcultfollowing.com/babysteps/blog/2018/04/27/an-alias-based-formulation-of-the-borrow-checker/
+[talk]: https://youtu.be/_agDeiWek8w
 [book]: https://rust-lang.github.io/polonius/
 
 ### Why the name "Polonius"?


### PR DESCRIPTION
Add a link to the talk, according to https://github.com/rust-lang/polonius/issues/191